### PR TITLE
Add LinksHover to show social links and add llms.txt file

### DIFF
--- a/app/components/links-hover.tsx
+++ b/app/components/links-hover.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import React, { useState } from 'react'
+import Link from 'next/link'
+import { socialLinks } from '../lib/constants'
+import { useIsMobile } from '../hooks'
+
+export default function LinksHover(): React.JSX.Element {
+  const [isVisible, setIsVisible] = useState<boolean>(false)
+  const isMobile = useIsMobile()
+
+  const handleMouseEnter = (): void => {
+    if (!isMobile) {
+      setIsVisible(true)
+    }
+  }
+
+  const handleMouseLeave = (): void => {
+    if (!isMobile) {
+      setIsVisible(false)
+    }
+  }
+
+  const handleClick = (e: React.MouseEvent): void => {
+    // On mobile, handle click to toggle
+    if (isMobile) {
+      e.preventDefault()
+      setIsVisible(!isVisible)
+    }
+  }
+
+  const handleTouchStart = (): void => {
+    // Additional touch handling for mobile
+    if (isMobile) {
+      setIsVisible(!isVisible)
+    }
+  }
+
+  return (
+    <div 
+      className="inline-flex items-center gap-1"
+      onMouseEnter={!isMobile ? handleMouseEnter : undefined}
+      onMouseLeave={!isMobile ? handleMouseLeave : undefined}
+    >
+      <span 
+        className="py-1 px-2 m-1 cursor-pointer select-none"
+        onClick={handleClick}
+        onTouchStart={isMobile ? handleTouchStart : undefined}
+      >
+        links
+      </span>
+      
+      {isVisible && (
+        <div className="inline-flex items-center gap-1">
+          {socialLinks.map((link, index) => (
+            <Link
+              key={index}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-all hover:text-neutral-800 dark:hover:text-neutral-200 py-1 px-2 m-1"
+            >
+              {link.text.toLowerCase()}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import DSIcon from './icons/ds-icon'
+import LinksHover from './links-hover'
 
 const navItems = {
   '/': {
@@ -34,13 +35,7 @@ export function Navbar() {
                   </Link>
                 )
               })}
-              <Link
-                href="https://nf.td/dylan"
-                className="cursor-pointer transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1"
-                target="_blank"
-              >
-                links
-              </Link>
+              <LinksHover />
             </div>
           </div>
         </nav>

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useIsMobile } from './use-is-mobile' 

--- a/app/hooks/use-is-mobile.ts
+++ b/app/hooks/use-is-mobile.ts
@@ -1,0 +1,17 @@
+import * as React from "react"
+
+export function useIsMobile(mobileBreakpoint: number = 768): boolean {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < mobileBreakpoint)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < mobileBreakpoint)
+    return () => mql.removeEventListener("change", onChange)
+  }, [mobileBreakpoint])
+
+  return !!isMobile
+} 

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,0 +1,6 @@
+export const socialLinks = [
+  { url: 'https://github.com/dylsteck', text: 'GitHub' },
+  { url: 'https://farcaster.xyz/dylsteck.eth', text: 'Farcaster' },
+  { url: 'https://x.com/Dylan_Steck', text: 'X' },
+  { url: 'https://linkedin.com/in/dylansteck', text: 'LinkedIn' }
+]

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import { socialLinks } from '../lib/constants'
+import { videos } from '../video/videos'
+
+function readFileContent(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+  } catch (error) {
+    return `[Error reading file: ${filePath}]`
+  }
+}
+
+function getAllMarkdownFiles(dirPath: string, arrayOfFiles: string[] = []): string[] {
+  try {
+    const files = fs.readdirSync(dirPath)
+
+    files.forEach(function(file) {
+      const fullPath = path.join(dirPath, file)
+      const stat = fs.statSync(fullPath)
+      
+      if (stat.isDirectory()) {
+        // Skip node_modules, .git, and other build directories
+        if (!['node_modules', '.git', '.next', 'dist', 'build'].includes(file)) {
+          arrayOfFiles = getAllMarkdownFiles(fullPath, arrayOfFiles)
+        }
+      } else {
+        // Include only markdown files
+        const ext = path.extname(file).toLowerCase()
+        if (ext === '.md') {
+          arrayOfFiles.push(fullPath)
+        }
+      }
+    })
+  } catch (error) {
+    console.error(`Error reading directory ${dirPath}:`, error)
+  }
+
+  return arrayOfFiles
+}
+
+function formatTitle(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+}
+
+export async function GET() {
+  try {
+    const projectRoot = process.cwd()
+    const appDir = path.join(projectRoot, 'app')
+    
+    let content = `# Dylan Steck - Full Content\n\n`
+    content += `This file contains all markdown content from [dylansteck.com](https://dylansteck.com)\n\n`
+
+    // Add main pages
+    content += `## Pages\n\n`
+    content += `- [Homepage](/) - Dylan Steck, Engineer at Base\n`
+    content += `- [RSS Feed](/rss) - RSS feed\n\n`
+
+    // Add blog posts with links
+    const blogPostsDir = path.join(appDir, 'blog', 'posts')
+    if (fs.existsSync(blogPostsDir)) {
+      content += `## Blog Posts\n\n`
+      const blogFiles = fs.readdirSync(blogPostsDir)
+        .filter(file => file.endsWith('.md'))
+        .sort()
+      
+      blogFiles.forEach(file => {
+        const slug = file.replace('.md', '')
+        const title = formatTitle(slug)
+        content += `- [${title}](/blog/${slug})\n`
+      })
+      content += `\n`
+    }
+
+    // Add videos section from constants
+    content += `## Videos\n\n`
+    videos.forEach(video => {
+      content += `- [${video.title}](/video/${video.id}) - ${video.description}\n`
+    })
+    content += `\n`
+
+    // Add contact/social links from constants
+    content += `## Contact\n\n`
+    socialLinks.forEach(link => {
+      content += `- [${link.text}](${link.url})\n`
+    })
+    content += `\n`
+
+    content += `${'='.repeat(80)}\n\n`
+
+    // Get all markdown files and include their content with better headers
+    const allMarkdownFiles = getAllMarkdownFiles(projectRoot)
+    
+    // Sort files by name for better organization
+    const sortedFiles = allMarkdownFiles.sort((a, b) => a.localeCompare(b))
+
+    // Add each markdown file's content with better headers
+    sortedFiles.forEach((filePath) => {
+      const relativePath = path.relative(projectRoot, filePath)
+      const fileContent = readFileContent(filePath)
+      
+      // Generate better header based on file type
+      if (relativePath.includes('app/blog/posts/')) {
+        const slug = path.basename(filePath, '.md')
+        const title = formatTitle(slug)
+        content += `## ${title} - [/blog/${slug}](/blog/${slug})\n\n`
+      } else {
+        content += `## ${relativePath}\n\n`
+      }
+      
+      content += fileContent
+      content += `\n\n${'-'.repeat(60)}\n\n`
+    })
+
+    content += `## About\n\n`
+    content += `Dylan Steck is an engineer at Base, focused on building products onchain that give people more agency.\n`
+    content += `This export contains all the markdown content from his personal website at dylansteck.com.\n`
+
+    return new NextResponse(content, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Disposition': 'inline; filename="llms-full.txt"',
+      },
+    })
+  } catch (error) {
+    console.error('Error generating llms-full.txt:', error)
+    return new NextResponse('Error generating full content export', { status: 500 })
+  }
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import { socialLinks } from '../lib/constants'
+import { videos } from '../video/videos'
+
+export async function GET() {
+  try {
+    const appDir = path.join(process.cwd(), 'app')
+    
+    let content = `# Dylan Steck\n\n`
+    content += `This is a directory of content on [dylansteck.com](https://dylansteck.com)\n\n`
+
+    // Add main pages
+    content += `## Pages\n\n`
+    content += `- [Homepage](/) - Dylan Steck, Engineer at Base\n`
+    content += `- [RSS Feed](/rss) - RSS feed\n\n`
+
+    // Add blog posts
+    const blogPostsDir = path.join(appDir, 'blog', 'posts')
+    if (fs.existsSync(blogPostsDir)) {
+      content += `## Blog Posts\n\n`
+      const blogFiles = fs.readdirSync(blogPostsDir)
+        .filter(file => file.endsWith('.md'))
+        .sort()
+      
+      blogFiles.forEach(file => {
+        const slug = file.replace('.md', '')
+        const title = slug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+        content += `- [${title}](/blog/${slug})\n`
+      })
+      content += `\n`
+    }
+
+    // Add all videos from constants
+    content += `## Videos\n\n`
+    videos.forEach(video => {
+      content += `- [${video.title}](/video/${video.id})\n`
+    })
+    content += `\n`
+
+    // Add contact/social links from constants
+    content += `## Contact\n\n`
+    socialLinks.forEach(link => {
+      content += `- [${link.text}](${link.url})\n`
+    })
+    content += `\n`
+
+    content += `## About\n\n`
+    content += `Dylan Steck is an engineer at Base, focused on building products onchain that give people more agency.\n`
+
+    return new NextResponse(content, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    })
+  } catch (error) {
+    console.error('Error generating llms.txt:', error)
+    return new NextResponse('Error generating directory', { status: 500 })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "author": "dylsteck",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "next dev --turbo",
+    "build": "next build --turbo",
     "start": "next start"
   },
   "dependencies": {
@@ -15,7 +15,7 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "geist": "1.3.1",
-    "next": "15.3.2",
+    "next": "15.3.4",
     "next-mdx-remote": "^5.0.0",
     "postcss": "^8.5.3",
     "react": "^19.1.0",


### PR DESCRIPTION
This PR adds some small changes:
- Adds a new `LinksHover` component so when the user hovers on the 'links' menu button(or click it on mobile), you see social media links to the side(GitHub, Farcaster, X, and LinkedIn)
- Adds a `llms.txt` and `llms-full.txt` linking to and showing the full content of the site
- Upgrades Next to `v15.3.4` and switches both dev server and builds to Turbopack with `--turbo` now that [all Turbopack builds pass on Next](https://areweturboyet.com)