### PR TITLE
chore: fix brittle blog embeds

### DIFF
--- a/app/components/cast.tsx
+++ b/app/components/cast.tsx
@@ -1,14 +1,27 @@
 import { FarcasterEmbed } from 'react-farcaster-embed/dist/client'
+import EmbedBoundary from './embed-boundary'
 
 interface CastProps {
   url: string
   [key: string]: any
 }
 
-export default function Cast({ url, ...props }: CastProps) {
+function CastFallback({ url }: { url: string }) {
   return (
     <div className="max-w-[600px] mx-auto my-6">
-      <FarcasterEmbed url={url} {...props} />
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        View cast on Farcaster
+      </a>
     </div>
+  )
+}
+
+export default function Cast({ url, ...props }: CastProps) {
+  return (
+    <EmbedBoundary fallback={<CastFallback url={url} />}>
+      <div className="max-w-[600px] mx-auto my-6">
+        <FarcasterEmbed url={url} {...props} />
+      </div>
+    </EmbedBoundary>
   )
 }

--- a/app/components/embed-boundary.tsx
+++ b/app/components/embed-boundary.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+type EmbedBoundaryProps = {
+  children: React.ReactNode
+  fallback: React.ReactNode
+}
+
+type EmbedBoundaryState = {
+  hasError: boolean
+}
+
+export default class EmbedBoundary extends React.Component<
+  EmbedBoundaryProps,
+  EmbedBoundaryState
+> {
+  state: EmbedBoundaryState = {
+    hasError: false,
+  }
+
+  static getDerivedStateFromError(): EmbedBoundaryState {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}

--- a/app/components/tweet.tsx
+++ b/app/components/tweet.tsx
@@ -1,14 +1,103 @@
-import { Tweet } from 'react-tweet'
+import {
+  EmbeddedTweet,
+  TweetNotFound,
+  TweetSkeleton,
+  useTweet,
+} from 'react-tweet'
+import type {
+  QuotedTweet,
+  Tweet as TweetData,
+  TweetEntities,
+} from 'react-tweet/api'
+import EmbedBoundary from './embed-boundary'
 
 interface TweetProps {
   id: string
+  apiUrl?: string
+  fetchOptions?: RequestInit
+  onError?: (error: unknown) => unknown
   [key: string]: any
+}
+
+type MaybeTweetEntities = Partial<TweetEntities> | null | undefined
+
+function normalizeTweetEntities(
+  entities: MaybeTweetEntities
+): TweetEntities {
+  return {
+    hashtags: Array.isArray(entities?.hashtags) ? entities.hashtags : [],
+    urls: Array.isArray(entities?.urls) ? entities.urls : [],
+    user_mentions: Array.isArray(entities?.user_mentions)
+      ? entities.user_mentions
+      : [],
+    symbols: Array.isArray(entities?.symbols) ? entities.symbols : [],
+    ...(Array.isArray(entities?.media) && entities.media.length > 0
+      ? { media: entities.media }
+      : {}),
+  }
+}
+
+function normalizeDisplayTextRange(tweet: TweetData | QuotedTweet) {
+  return Array.isArray(tweet.display_text_range)
+    ? tweet.display_text_range
+    : ([0, Array.from(tweet.text || '').length] as [number, number])
+}
+
+function normalizeTweet(tweet: TweetData): TweetData {
+  return {
+    ...tweet,
+    display_text_range: normalizeDisplayTextRange(tweet),
+    entities: normalizeTweetEntities(tweet.entities),
+    quoted_tweet: tweet.quoted_tweet
+      ? {
+          ...tweet.quoted_tweet,
+          display_text_range: normalizeDisplayTextRange(tweet.quoted_tweet),
+          entities: normalizeTweetEntities(tweet.quoted_tweet.entities),
+        }
+      : undefined,
+  }
+}
+
+function TweetEmbed({
+  id,
+  apiUrl,
+  fetchOptions,
+  onError,
+  ...props
+}: TweetProps) {
+  const { data, error, isLoading } = useTweet(id, apiUrl, fetchOptions)
+
+  if (isLoading) {
+    return <TweetSkeleton />
+  }
+
+  if (error || !data) {
+    return <TweetNotFound error={onError ? onError(error) : error} />
+  }
+
+  return <EmbeddedTweet tweet={normalizeTweet(data)} {...props} />
+}
+
+function TweetFallback({ id }: { id: string }) {
+  return (
+    <div className="max-w-[600px] mx-auto my-6">
+      <a
+        href={`https://x.com/i/status/${id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        View tweet on X
+      </a>
+    </div>
+  )
 }
 
 export default function TweetComponent({ id, ...props }: TweetProps) {
   return (
-    <div className="max-w-[600px] mx-auto my-6">
-      <Tweet id={id} {...props} />
-    </div>
+    <EmbedBoundary fallback={<TweetFallback id={id} />}>
+      <div className="max-w-[600px] mx-auto my-6">
+        <TweetEmbed id={id} {...props} />
+      </div>
+    </EmbedBoundary>
   )
 }


### PR DESCRIPTION
## Summary
- normalize missing tweet entity arrays before rendering `react-tweet` embeds
- add a small embed error boundary so tweet/cast payload issues fall back to outbound links instead of crashing the blog route

## Verification
- npm run build
- local dev route `/blog/agentic-workspaces` in Chromium: 0 console errors, 2 tweet embeds, 1 Farcaster embed, no fallback links
- topbar Feed navigation smoke test: `/feed` loaded with 0 console errors